### PR TITLE
fix: mueve La Rioja a provincia, deja comunidad vacía

### DIFF
--- a/_data/comunidades/larioja.json
+++ b/_data/comunidades/larioja.json
@@ -1,30 +1,4 @@
 {
   "name": "La Rioja",
-  "webs": [
-     {
-      "url": "larioja.org",
-      "name": "Gobierno de La Rioja",
-      "twitter": "lariojaorg"
-    },
-    {
-      "url": "www.riojasalud.es",
-      "name": "Servicio Riojano de Salud",
-      "twitter": "riojasalud"
-    },
-    {
-      "url": "www.ader.es",
-      "name": "Agencia de Desarrollo Económico de La Rioja",
-      "twitter": "een_ader"
-    },
-    {
-      "url": "www.irj.es",
-      "name": "Instituto Riojano de la Juventud",
-      "twitter": "irjjuventud"
-    },
-    {
-      "url": "www.agendadigitalriojana.es",
-      "name": "Agencia Digital de La Rioja",
-      "twitter": "RiojaDigital"
-    }
-  ]
+  "webs": []
 }

--- a/_data/provincias/larioja.json
+++ b/_data/provincias/larioja.json
@@ -1,0 +1,30 @@
+{
+  "name": "La Rioja",
+  "webs": [
+     {
+      "url": "larioja.org",
+      "name": "Gobierno de La Rioja",
+      "twitter": "lariojaorg"
+    },
+    {
+      "url": "www.riojasalud.es",
+      "name": "Servicio Riojano de Salud",
+      "twitter": "riojasalud"
+    },
+    {
+      "url": "www.ader.es",
+      "name": "Agencia de Desarrollo Económico de La Rioja",
+      "twitter": "een_ader"
+    },
+    {
+      "url": "www.irj.es",
+      "name": "Instituto Riojano de la Juventud",
+      "twitter": "irjjuventud"
+    },
+    {
+      "url": "www.agendadigitalriojana.es",
+      "name": "Agencia Digital de La Rioja",
+      "twitter": "RiojaDigital"
+    }
+  ]
+}


### PR DESCRIPTION
De esta manera se mostaría la provincia en el listado.