### PR TITLE
Add Villanueva del Trabuco

### DIFF
--- a/_data/provincias/malaga.json
+++ b/_data/provincias/malaga.json
@@ -26,6 +26,11 @@
       "url": "www.istan.es",
       "name": "Ayuntamiento de Istán",
       "twitter": "AytoIstan"
+    },
+    {
+      "url": "www.villanuevadeltrabuco.es",
+      "name": "Ayuntamiento de Villanueva del Trabuco",
+      "twitter": "vvatrabuco"
     }
   ]
 }


### PR DESCRIPTION
Añadida villanueva del trabuco, una pequeña localidad Malagueña con una nota actual de F, con solo 5/11 tests pasados.