### PR TITLE
Sustitución

### DIFF
--- a/_data/comunidades/comunidad-valenciana.json
+++ b/_data/comunidades/comunidad-valenciana.json
@@ -26,16 +26,15 @@
       "name": "Circuit de la Comunitat Valenciana",
       "twitter": "Circuit Valencia"
     },
-
+    {
+      "url": "invattur.es",
+      "name": "Instituto Valenciano de Tecnologías Turísticas",
+      "twitter": "GVAinvattur"
+    },
     {
       "url": "san.gva.es",
       "name": "Conselleria Sanitat i Salut Pública",
       "twitter": "GVAsanitat"
-    },
-    {
-      "url": "www.dival.es",
-      "name": "Diputacio de Valencia",
-      "twitter": "dipvalencia"
     },
     {
       "url": "www.ceice.gva.es",


### PR DESCRIPTION
 He retirado dival por pertenecer a la Diputación de Valencia y por tanto a la provincia de Valencia.
He puesto otra web.