### PR TITLE
feat: support tags/labels

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -17,12 +17,13 @@ const fs = require("fs");
       webs: file.webs,
     }))
     .map(({ territorio_id, territorio, webs }) =>
-      webs.map((w) => ({
+      webs.map((web) => ({
         territorio_id,
         territorio,
-        url: w.url,
-        name: w.name,
-        twitter: w.twitter,
+        url: web.url,
+        name: web.name,
+        twitter: web.twitter,
+        tags: web.tags
       }))
     )
     .flat()
@@ -31,10 +32,7 @@ const fs = require("fs");
       try {
         results = JSON.parse(
           fs.readFileSync(
-            `_data/results/${obj.url.replace(
-              new RegExp("\\.", "g"),
-              "!"
-            )}.json`,
+            `_data/results/${obj.url.replace(new RegExp("\\.", "g"), "!")}.json`,
             "utf8"
           )
         );

--- a/_data/general.json
+++ b/_data/general.json
@@ -19,7 +19,8 @@
     {
       "url": "www.mscbs.gob.es",
       "name": "Ministerio de Sanidad, Consumo y Bienestar Social",
-      "twitter": "sanidadgob"
+      "twitter": "sanidadgob",
+      "tags": ["ministerios"]
     },
     {
       "url": "www.renfe.com",
@@ -53,8 +54,9 @@
     },
     {
       "url": "www.hacienda.gob.es",
-      "name": "Ministerio de hacienda",
-      "twitter": "haciendagob"
+      "name": "Ministerio de Hacienda",
+      "twitter": "haciendagob",
+      "tags": ["ministerios"]
     },
     {
       "url": "www.agenciatributaria.es",
@@ -74,7 +76,8 @@
     {
       "url": "www.interior.gob.es",
       "name": "Ministerio de Interior",
-      "twitter": "interiorgob"
+      "twitter": "interiorgob",
+      "tags": ["ministerios"]
     },
     {
       "url": "www.cni.es",
@@ -94,22 +97,26 @@
     {
       "url": "www.defensa.gob.es",
       "name": "Ministerio de Defensa",
-      "twitter": "Defensagob"
+      "twitter": "Defensagob",
+      "tags": ["ministerios"]
     },
     {
       "url": "www.ciencia.gob.es",
       "name": "Ministerio de Ciencia e Innovación",
-      "twitter": "CienciaGob"
+      "twitter": "CienciaGob",
+      "tags": ["ministerios"]
     },
     {
       "url": "www.culturaydeporte.gob.es",
       "name": "Ministerio de Cultura y Deporte",
-      "twitter": "culturagob"
+      "twitter": "culturagob",
+      "tags": ["ministerios"]
     },
     {
       "url": "www.mineco.gob.es",
       "name": "Ministerio de Asuntos Económicos y Transformación Digital",
-      "twitter": "_minegob"
+      "twitter": "_minegob",
+      "tags": ["ministerios"]
     },
     {
       "url": "avancedigital.gob.es",
@@ -119,17 +126,20 @@
     {
       "url": "www.mjusticia.gob.es",
       "name": "Ministerio de Justicia",
-      "twitter": "justiciagob"
+      "twitter": "justiciagob",
+      "tags": ["ministerios"]
     },
     {
       "url": "www.exteriores.gob.es",
       "name": "Ministerio de Exteriores",
-      "twitter": "MAECgob"
+      "twitter": "MAECgob",
+      "tags": ["ministerios"]
     },
     {
       "url": "www.igualdad.gob.es",
       "name": "Ministerio de Igualdad",
-      "twitter": "IgualdadGob"
+      "twitter": "IgualdadGob",
+      "tags": ["ministerios"]
     },
     {
       "url": "www.aepd.es",

--- a/_data/tags.json
+++ b/_data/tags.json
@@ -1,0 +1,6 @@
+[
+    {
+        "name": "ministerios",
+        "description": "Ministerios del Gobierno de España"
+    }
+]

--- a/assets/sass/libs/_breakpoints.scss
+++ b/assets/sass/libs/_breakpoints.scss
@@ -4,7 +4,7 @@
 
 	/// Breakpoints.
 	/// @var {list}
-	$breakpoints: () !global;
+	$breakpoints: ();
 
 // Mixins.
 
@@ -41,7 +41,7 @@
 				}
 
 			// Less than or equal.
-				@elseif (str-slice($query, 0, 2) == '<=') {
+				@else if (str-slice($query, 0, 2) == '<=') {
 
 					$op: 'lte';
 					$breakpoint: str-slice($query, 3);
@@ -49,7 +49,7 @@
 				}
 
 			// Greater than.
-				@elseif (str-slice($query, 0, 1) == '>') {
+				@else if (str-slice($query, 0, 1) == '>') {
 
 					$op: 'gt';
 					$breakpoint: str-slice($query, 2);
@@ -57,7 +57,7 @@
 				}
 
 			// Less than.
-				@elseif (str-slice($query, 0, 1) == '<') {
+				@else if (str-slice($query, 0, 1) == '<') {
 
 					$op: 'lt';
 					$breakpoint: str-slice($query, 2);
@@ -65,7 +65,7 @@
 				}
 
 			// Not.
-				@elseif (str-slice($query, 0, 1) == '!') {
+				@else if (str-slice($query, 0, 1) == '!') {
 
 					$op: 'not';
 					$breakpoint: str-slice($query, 2);
@@ -100,22 +100,22 @@
 									}
 
 								// Less than or equal (<= y)
-									@elseif ($op == 'lte') {
+									@else if ($op == 'lte') {
 										$media: 'screen and (max-width: ' + $y + ')';
 									}
 
 								// Greater than (> y)
-									@elseif ($op == 'gt') {
+									@else if ($op == 'gt') {
 										$media: 'screen and (min-width: ' + ($y + 1) + ')';
 									}
 
 								// Less than (< 0 / invalid)
-									@elseif ($op == 'lt') {
+									@else if ($op == 'lt') {
 										$media: 'screen and (max-width: -1px)';
 									}
 
 								// Not (> y)
-									@elseif ($op == 'not') {
+									@else if ($op == 'not') {
 										$media: 'screen and (min-width: ' + ($y + 1) + ')';
 									}
 
@@ -135,22 +135,22 @@
 									}
 
 								// Less than or equal (<= inf / anything)
-									@elseif ($op == 'lte') {
+									@else if ($op == 'lte') {
 										$media: 'screen';
 									}
 
 								// Greater than (> inf / invalid)
-									@elseif ($op == 'gt') {
+									@else if ($op == 'gt') {
 										$media: 'screen and (max-width: -1px)';
 									}
 
 								// Less than (< x)
-									@elseif ($op == 'lt') {
+									@else if ($op == 'lt') {
 										$media: 'screen and (max-width: ' + ($x - 1) + ')';
 									}
 
 								// Not (< x)
-									@elseif ($op == 'not') {
+									@else if ($op == 'not') {
 										$media: 'screen and (max-width: ' + ($x - 1) + ')';
 									}
 
@@ -170,22 +170,22 @@
 									}
 
 								// Less than or equal (<= y)
-									@elseif ($op == 'lte') {
+									@else if ($op == 'lte') {
 										$media: 'screen and (max-width: ' + $y + ')';
 									}
 
 								// Greater than (> y)
-									@elseif ($op == 'gt') {
+									@else if ($op == 'gt') {
 										$media: 'screen and (min-width: ' + ($y + 1) + ')';
 									}
 
 								// Less than (< x)
-									@elseif ($op == 'lt') {
+									@else if ($op == 'lt') {
 										$media: 'screen and (max-width: ' + ($x - 1) + ')';
 									}
 
 								// Not (< x and > y)
-									@elseif ($op == 'not') {
+									@else if ($op == 'not') {
 										$media: 'screen and (max-width: ' + ($x - 1) + '), screen and (min-width: ' + ($y + 1) + ')';
 									}
 

--- a/assets/sass/libs/_mixins.scss
+++ b/assets/sass/libs/_mixins.scss
@@ -24,7 +24,7 @@
 		@if ($category == brands) {
 			font-family: 'Font Awesome 5 Brands';
 		}
-		@elseif ($category == solid) {
+		@else if ($category == solid) {
 			font-family: 'Font Awesome 5 Free';
 			font-weight: 900;
 		}

--- a/assets/sass/libs/_vendor.scss
+++ b/assets/sass/libs/_vendor.scss
@@ -362,7 +362,7 @@
 			}
 
 		// Expand just the value?
-			@elseif $expandValue {
+			@else if $expandValue {
 			    @each $vendor in $vendor-prefixes {
 			        #{$property}: #{str-replace-all($value, '-prefix-', $vendor)};
 			    }

--- a/pages/tag.njk
+++ b/pages/tag.njk
@@ -1,0 +1,17 @@
+---
+layout: base
+pagination:
+  data: tags
+  size: 1
+  alias: tag
+permalink: "listas/{{ tag.name | slug }}"
+---
+
+<h1>{{ tag.name }}</h1>
+<h2>{{ tag.description }}</h2>
+
+{% for site in all %}
+  {% if site.tags and tag.name in site.tags %}
+    {{ site.name }}<br/> <!-- TO BE COMPLETED WITH THE SAME TABLE -->
+  {% endif %}
+{% endfor %}


### PR DESCRIPTION
Soporte básico de tags.
- Los sitios admiten un array opcional de tags.
- Hay un nuevo tags.json con los tags soportados. Me gustaría evitar este fichero, ya que esa info está en el all.json, pero no he visto forma fácil. Igual @adrm, que conoces más eleventy, conoces algo trivial (he visto que se pueden añadir collections y cosas así). Tener un tags.json separado tiene alguna ventaja (puedes meter más campos como la descripción del tag y tienes más control sobre qué tags quieres realmente publicar), tampoco lo veo mal.
- Para cada tag se genera una página con la lista de sitios (tag.njk). Ahora mismo pinta el nombre porque es solo una poc, ahí iría una tabla igual que las demás.

![Screenshot 2021-02-11 at 21 51 49](https://user-images.githubusercontent.com/673420/107697343-671f9180-6cb3-11eb-95f7-1451a880568c.png)
