### PR TITLE
Sustituido "electónica" por "electrónica"

### DIFF
--- a/_data/provincias/valencia.json
+++ b/_data/provincias/valencia.json
@@ -144,7 +144,7 @@
     },
     {
       "url": "sede.valencia.es",
-      "name": "Sede electónica València",
+      "name": "Sede electrónica València",
       "twitter": "AjuntamentVLC"
     },
 


### PR DESCRIPTION
Pequeña errata corregida!