### PR TITLE
Fichero para datos de Granada

### DIFF
--- a/_data/provincias/granada.json
+++ b/_data/provincias/granada.json
@@ -1,0 +1,21 @@
+{
+  "name": "Granada",
+  "comunidad": "andalucia",
+  "webs": [
+    {
+       "url": "www.granada.es",
+       "name": "Ayuntamiento de Granada",
+       "twitter": "aytogr"
+    },
+    {
+       "url": "www.granadatur.com",
+       "name": "Portal de Turismo de Granada",
+       "twitter": "granadaturismo"
+    },
+    {
+      "url": "www.soportujar.es",
+      "name": "Ayuntamiento de Soportújar",
+      "twitter": ""
+    }
+  ]
+}


### PR DESCRIPTION
Creación del fichero para empezar a guardar datos sobre la provincia de Granada.
_Soportújar no tiene Twitter_