### PR TITLE
chore: more aggresive crawling

### DIFF
--- a/crawler/sites-parser.js
+++ b/crawler/sites-parser.js
@@ -5,8 +5,8 @@
 const fs = require('fs');
 const glob = require('fast-glob');
 
-const MAX_TIME_TO_REFRESH_MILLIS = 3 * 24 * 60 * 60 * 1000; // 3 days, can be increased when we have many sites to scan
-const MAX_RESULTS = 100;
+const MAX_TIME_TO_REFRESH_MILLIS = 2 * 24 * 60 * 60 * 1000; // 3 days, can be increased when we have many sites to scan
+const MAX_RESULTS = 200;
 
 /**
  * Obtiene los ficheros global, de comunidades y provincias.


### PR DESCRIPTION
- considera datos antiguos los que tienen >2 días (en lugar de 3)
- refresca los datos de hasta 200 sitios en cada ejecución (en lugar de 100)