### PR TITLE
Añade Educación de la Xunta de Galicia

### DIFF
--- a/_data/comunidades/galicia.json
+++ b/_data/comunidades/galicia.json
@@ -22,6 +22,16 @@
       "twitter": "Xunta"
     },
     {
+      "url": "casaut.edu.xunta.gal",
+      "name": "Portal de autenticación de la Consellería de Educación de Galicia",
+      "twitter": "Xunta"
+    },
+    {
+      "url": "www.edu.xunta.gal",
+      "name": "Servicios de la Consellería de Educación de Galicia",
+      "twitter": "Xunta"
+    },
+    {
       "url": "www.caminodesantiago.gal",
       "name": "Camino de Santiago",
       "twitter": ""


### PR DESCRIPTION
Los servicios de Educación incluyen el acceso al correo electrónico (webmail) del personal docente, o al sistema de evaluación de los alumnos.