### PR TITLE
Eliminar www.uab.cat de barcelona.json

### DIFF
--- a/_data/provincias/barcelona.json
+++ b/_data/provincias/barcelona.json
@@ -38,11 +38,6 @@
       "twitter": "bcn_ajuntament"
     },
     {
-      "url": "www.uab.cat",
-      "name": "Universitat Autònoma de Barcelona",
-      "twitter": "UABBarcelona"
-    },
-    {
       "url": "www.firabarcelona.com",
       "name": "Fira Barcelona",
       "twitter": "fira_barcelona"


### PR DESCRIPTION
Elimino la web de la Universitat Autònoma de Barcelona para que no esté duplicada (también está en catalunya.json con el resto de universidades públicas).