### PR TITLE
fix: update deprecated ubuntu version

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/analyze_dmarc.yml
+++ b/.github/workflows/analyze_dmarc.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/results_and_build.yml
+++ b/.github/workflows/results_and_build.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/twitter.yml
+++ b/.github/workflows/twitter.yml
@@ -9,14 +9,14 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v2
 
       - uses: actions/setup-node@v2
         with:
-          node-version: "14"
+          node-version: "20"
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
No están saltando los pipelines porque han deprecado la versión ubuntu-20 de las github actions. Por lo visto mantienen dos versiones LTE hacia atrás y ahora está la 22 y la 24.

Actualizo a la última ubuntu-24 esperando que funcione.